### PR TITLE
action_rec headers not found fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/build
-build
+*build*
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,6 @@ find_package(ament_index_cpp REQUIRED)
 
 find_package(YARP COMPONENTS os idl_tools dev REQUIRED)
 
-add_subdirectory(bts/src)
-add_subdirectory(interfaces)
 add_subdirectory(components)
+add_subdirectory(bts/src)
+

--- a/bts/src/CMakeLists.txt
+++ b/bts/src/CMakeLists.txt
@@ -8,7 +8,13 @@
 # Create the custom_leaf_nodes library
 add_library(custom_leaf_nodes STATIC)
 
-include_directories(actions conditions)
+include_directories(
+        actions
+        conditions
+        ${CMAKE_SOURCE_DIR}/components/action_recognition/include
+        ${CMAKE_SOURCE_DIR}/components/object_detection/include
+)
+
 target_sources(custom_leaf_nodes
   PRIVATE
   actions/ask_to_get_closer.cpp
@@ -22,8 +28,9 @@ target_include_directories(custom_leaf_nodes
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_link_libraries(custom_leaf_nodes
-  PUBLIC
+  PRIVATE
     BT::behaviortree_cpp_v3
+    YARP::YARP_os
     )
 
 

--- a/bts/src/conditions/correct_action_recognized.cpp
+++ b/bts/src/conditions/correct_action_recognized.cpp
@@ -35,7 +35,7 @@
 #include <thread>
 #include <yarp/os/Network.h>
 #include <yarp/os/Port.h>
-#include <ActionRecognition.h>
+#include <ActionRecognitionInterface.h>
 
 
 CorrectActionRecognized::CorrectActionRecognized(string name, const NodeConfiguration& config) :

--- a/bts/src/conditions/correct_action_recognized.h
+++ b/bts/src/conditions/correct_action_recognized.h
@@ -27,7 +27,7 @@
 
 
 #include <behaviortree_cpp_v3/condition_node.h>
-/*#include <ActionRecognition.h>*/
+#include <ActionRecognitionInterface.h>
 #include <string>
 #include <future>
 using namespace BT;
@@ -42,7 +42,7 @@ public:
 private:
     bool init(std::string);
     static BT::PortsList providedPorts() {}
-    ActionRecognition action_recognition_client_;
+    ActionRecognitionInterface action_recognition_client_;
     bool is_ok_{false};
 
 

--- a/components/action_recognition/CMakeLists.txt
+++ b/components/action_recognition/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
  # Create the component (navigation client)
 find_package(YARP COMPONENTS os dev REQUIRED)
 include_directories(include)
+
 add_executable(action_recognition)  # ADDED
 target_sources(action_recognition  # DECOMMENfED
   PRIVATE

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -5,6 +5,5 @@
 #                                                                              #
 ################################################################################
 
-add_subdirectory(counter)
 add_subdirectory(action_recognition)
 add_subdirectory(object_detection)


### PR DESCRIPTION
fixed the bug by adding the headers path to include_directories in bts/src/CMakeList. This commit also contains the fix to the not-finding-yarp-os bug in the same Cmakefile