### PR TITLE
Linked AR Component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CONFIG_PATH}")
 # BehaviorTree.CPP links Boost::coroutine, but does not look for it
 find_package(Boost COMPONENTS coroutine REQUIRED)
 find_package(behaviortree_cpp_v3 REQUIRED)
-find_package(ament_index_cpp REQUIRED)
 
 find_package(YARP COMPONENTS os idl_tools dev REQUIRED)
 

--- a/bts/src/CMakeLists.txt
+++ b/bts/src/CMakeLists.txt
@@ -29,6 +29,7 @@ target_include_directories(custom_leaf_nodes
 
 target_link_libraries(custom_leaf_nodes
   PRIVATE
+    action_recognition_interface
     BT::behaviortree_cpp_v3
     YARP::YARP_os
     )

--- a/bts/src/conditions/correct_action_recognized.cpp
+++ b/bts/src/conditions/correct_action_recognized.cpp
@@ -72,3 +72,8 @@ NodeStatus CorrectActionRecognized::tick()
 {
     return action_recognition_client_.get_action() == 4 ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
 }
+
+PortsList CorrectActionRecognized::providedPorts()
+{
+    return { };
+}

--- a/bts/src/conditions/correct_action_recognized.h
+++ b/bts/src/conditions/correct_action_recognized.h
@@ -38,17 +38,12 @@ class CorrectActionRecognized :  public ConditionNode
 public:
     CorrectActionRecognized(string name, const NodeConfiguration &config);
     NodeStatus tick() override;
+    static PortsList providedPorts();
 
 private:
     bool init(std::string);
-    static BT::PortsList providedPorts() {}
     ActionRecognitionInterface action_recognition_client_;
     bool is_ok_{false};
-
-
-
-
-
 };
 
 

--- a/bts/src/conditions/human_not_too_far.h
+++ b/bts/src/conditions/human_not_too_far.h
@@ -38,10 +38,10 @@
 using namespace BT;
 using namespace std;
 
-class HandoutSuccessful :  public ConditionNode
+class HumanNotTooFar :  public ConditionNode
 {
 public:
-    HandoutSuccessful(string name, const NodeConfiguration &config);
+    HumanNotTooFar(string name, const NodeConfiguration &config);
     NodeStatus tick() override;
     static PortsList providedPorts();
 

--- a/bts/src/run_bt.cpp
+++ b/bts/src/run_bt.cpp
@@ -68,6 +68,7 @@ int main(int argc, char *argv[])
     BehaviorTreeFactory bt_factory;
     bt_factory.registerNodeType<AskToGetCloser>("AskToGetCloser");
     bt_factory.registerNodeType<HandoutSuccessful>("HandoutSuccessful");
+    bt_factory.registerNodeType<CorrectActionRecognized>("CorrectActionRecognized");
 
     BT::Tree tree = bt_factory.createTreeFromFile(fileName);
 

--- a/components/action_recognition/CMakeLists.txt
+++ b/components/action_recognition/CMakeLists.txt
@@ -27,3 +27,17 @@ target_link_libraries(action_recognition  # DECOMMENTED
     YARP::YARP_os
     YARP::YARP_init
     YARP::YARP_dev)
+
+
+find_package(YARP COMPONENTS os dev REQUIRED)
+include_directories(include)
+
+add_library(action_recognition_interface)  # ADDED
+target_sources(action_recognition_interface  # DECOMMENfED
+        PRIVATE
+        ActionRecognitionInterface.cpp)  # DECOMMENTED
+target_link_libraries(action_recognition_interface  # DECOMMENTED
+        PRIVATE
+        YARP::YARP_os
+        YARP::YARP_init
+        YARP::YARP_dev)


### PR DESCRIPTION
correct action recognized now compiles together with the action recognition component. I had to make a library of ActionRecognitionInterface.cpp and to link it to the condition nodes